### PR TITLE
Remove useless PHPUnit versions definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": ">=7.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5"
+        "phpunit/phpunit": "^6.5"
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
## Introduction

- It's about removing useless `PHPUnit` versions in `composer.json`.
- This package requires `php-7.0` version at least and the PHPUnit version should be `6.x` at least.
And it's fine to remove useless PHPUnit versions definition in `composer.json`.

<!-- Put a cross `x` in relevant boxes below -->
- [x] General improvement