### PR TITLE
Add executable file assertion

### DIFF
--- a/src/Asserts.php
+++ b/src/Asserts.php
@@ -72,4 +72,18 @@ trait Asserts
     {
         $this->assertFalse(\array_keys($array) !== \range(0, \count($array) - 1), $message);
     }
+
+    public function assertFileIsExecutable(string $filePath, string $message = '')
+    {
+        \clearstatcache();
+
+        $this->assertTrue(\is_executable($filePath), $message);
+    }
+
+    public function assertFileIsNotExecutable(string $filePath, string $message = '')
+    {
+        \clearstatcache();
+
+        $this->assertFalse(\is_executable($filePath), $message);
+    }
 }

--- a/tests/AssertsTest.php
+++ b/tests/AssertsTest.php
@@ -99,4 +99,14 @@ class AssertsTest extends TestCase
 
         $this->assertIsNotAssocArray($assocArray);
     }
+
+    public function testAssertFileIsExecutable()
+    {
+        $this->assertFileIsExecutable('/bin/sh');
+    }
+
+    public function testAssertFileIsNotExecutable()
+    {
+        $this->assertFileIsNotExecutable(__DIR__ . '/composer.json');
+    }
 }


### PR DESCRIPTION
## Introduction

- Resolves issue #11.
- Add the `assertFileIsExecutable` and `assertFileIsNotExecutable` to assert the given file path is executable.

<!-- Put a cross `x` in relevant boxes below -->
- [X] New feature
- [ ] Fix for ... <!-- (the issue/bug) -->
- [ ] General improvement
- [ ] Backward incompatible change